### PR TITLE
update easydefi infura api key

### DIFF
--- a/defi/easydefi/src/ethbot/conf/base.py
+++ b/defi/easydefi/src/ethbot/conf/base.py
@@ -12,7 +12,7 @@ gasPriceOfAddLiquidity = 60000000000
 
 est_gas = "1eth"
 
-providerOfNetwork = "https://ropsten.infura.io/v3/af5a1d6c6ae04585b340adc84718a3c4"
+providerOfNetwork = "https://ropsten.infura.io/v3/3fa341cc4f6f4c70b50fc59fa17bd107"
 
 
 ONEHUNDRED = 100000000000000000000


### PR DESCRIPTION
旧的infura api 不能用了( infura project误删除 )
更新了新的infura api